### PR TITLE
Add json-loader to webpack config and use request library ajax calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,14 @@
     "morgan": "~1.7.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
+    "request": "^2.78.0",
+    "request-promise": "^4.1.1",
     "serve-favicon": "~2.3.0"
   },
   "devDependencies": {
     "eslint": "^3.10.0",
     "html-webpack-plugin": "^2.24.1",
+    "json-loader": "^0.5.4",
     "pre-commit": "^1.1.3",
     "react-hot-loader": "^3.0.0-beta.6",
     "webpack": "^1.13.3",

--- a/src/js/song-input.js
+++ b/src/js/song-input.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var R = React.DOM;
+var Request = require('request-promise');
 
 module.exports = React.createClass({
   render: function() {
@@ -26,21 +27,24 @@ module.exports = React.createClass({
     );
   },
   submit: function() {
-    var data = this.state.inputValue;
-    var request = new Request({
+    var data = {input: this.state.inputValue};
+
+    Request({
       method: 'POST',
       url: 'http://localhost:3000/submit',
-      body: data,
-      headers: new Headers({
-        'Content-Type': 'application-json'
-      })
-    });
-    request = JSON.stringify(request);
-    fetch(request);
-    // .then(function(res) {
-    //   // console.log('client side data -->', res);
-    // });
+      body: JSON.stringify(data),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+    .then(function(data){
+      console.log('client data -->', data);
+    })
+    .catch(function(err) {
+      console.log('client error -->', err);
+    })
   },
+
   updateInputData: function() {
     var value = this.refs.playlistInput.value;
     this.setState({inputValue: value});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,11 +15,18 @@ var webpackConfig = {
   },
 
   module: {
-    loaders: [{
-      test: /\.js?$/,
-      loader: 'react-hot-loader/webpack'
-    }]
+    loaders: [
+      { test: /\.js?$/, loader: 'react-hot-loader/webpack' },
+      { test: /\.json?$/, loader: 'json-loader' }
+    ]
   },
+
+  node: {
+  console: true,
+  fs: 'empty',
+  net: 'empty',
+  tls: 'empty'
+},
 
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Requests to routes now working as expected. To see, open dev tools in
browser with terminal thats running webpack (npm start) side by side,
type in input and click submit. Should see string logged in
both terminal and in browser console. Terminal should also GET request
with status of 200.